### PR TITLE
Spanish locale and unpublished to form actions

### DIFF
--- a/resources/lang/es/actions.php
+++ b/resources/lang/es/actions.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'publish' => 'Publicar',
+    'publish_and_create_another' => 'Publicar y crear otro',
+    'unpublish' => 'Despublicar',
+    'save-draft' => 'Guardar borrador',
+];

--- a/resources/lang/es/paginator.php
+++ b/resources/lang/es/paginator.php
@@ -1,0 +1,15 @@
+<?php
+return [
+    'title' => 'Revisiones',
+
+    'counts' => [
+        'overview' => ':published, :drafts, :revisions',
+        'published' => ':count publicado|:count publicados',
+        'drafts' => ':count borrador|:count borradores',
+        'revisions' => ':count/:max revisiones',
+    ],
+
+    'published' => 'Publicados',
+    'draft' => 'Borradores',
+    'current' => 'Seleccionado',
+];

--- a/resources/lang/es/tables.php
+++ b/resources/lang/es/tables.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'draftable-table' => [
+        'title' => 'Borradores',
+    ],
+];

--- a/src/Admin/Resources/Pages/Edit/Draftable.php
+++ b/src/Admin/Resources/Pages/Edit/Draftable.php
@@ -73,11 +73,6 @@ trait Draftable
             );
     }
 
-    protected function getActions(): array
-    {
-        return [];
-    }
-
     protected function getFormActions(): array
     {
         return [

--- a/src/Admin/Resources/Pages/Edit/Draftable.php
+++ b/src/Admin/Resources/Pages/Edit/Draftable.php
@@ -75,10 +75,7 @@ trait Draftable
 
     protected function getActions(): array
     {
-        return [
-            UnpublishAction::make(),
-            ...parent::getActions(),
-        ];
+        return [];
     }
 
     protected function getFormActions(): array
@@ -86,6 +83,7 @@ trait Draftable
         return [
             ...array_slice(parent::getFormActions(), 0, 1),
             SaveDraftAction::make(),
+            UnpublishAction::make(),
             ...array_slice(parent::getFormActions(), 1),
         ];
     }


### PR DESCRIPTION
This fork only adds Spanish localization and it moves the unpublished action to the form actions (where it is properly displayed). Hope is helps.