### PR TITLE
Add support for SoftDeletes

### DIFF
--- a/src/Tables/Http/Livewire/RevisionsPaginator.php
+++ b/src/Tables/Http/Livewire/RevisionsPaginator.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class RevisionsPaginator extends Component
 {
@@ -31,7 +32,9 @@ class RevisionsPaginator extends Component
      */
     public function updateRevisions(int $id): void
     {
-        $record = $this->record::withDrafts()->find($id);
+        $record = $this->record::withoutGlobalScopes([
+            SoftDeletingScope::class,
+        ])->withDrafts()->find($id);
 
         $this->revisions = $record->revisions()
 //            ->orderByDesc('is_current')


### PR DESCRIPTION
This PR adds draftable support for Models that use SoftDeletes.

## Problem
When using SoftDeletes feature. `$record->revisions()` does not work and throws error for using `revisons()` method on null.

```php
// Does not work.
$record = $this->record::withDrafts()->find($id);

        $this->revisions = $record->revisions()
            ->orderByDesc('updated_at')
            ->get();
```

## Solution
We can remove the SoftDeletes global scope when fetching the model.

```php
// This would work.
use Illuminate\Database\Eloquent\SoftDeletingScope;

$record = $this->record::withoutGlobalScopes([
            SoftDeletingScope::class,
        ])->withDrafts()->find($id);

        $this->revisions = $record->revisions()
            ->orderByDesc('updated_at')
            ->get();
```

Thanks! I am open to any changes/reviews.